### PR TITLE
Fix issue with Redux Dev Tools breaking in Firefox (and improve perf)

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -27,14 +27,30 @@ const config = {
 
 const history = createBrowserHistory()
 
-let persistedReducer = persistCombineReducers(config, rootReducer( history ) );
+const persistedReducer = persistCombineReducers(config, rootReducer( history ) );
 
-let store = createStore( persistedReducer, compose(
-	window.devToolsExtension ? window.devToolsExtension() : f => f,
+const composeEnhancers =
+	typeof window === 'object' &&
+	window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?   
+		window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+			stateSanitizer: ( state ) => {
+				if (!state.data) return state;
+				const data = {};
+				Object.keys(state.data).forEach(key => {
+					data[key] = { __TRUNCATED: true };
+				});
+				return { 
+					...state,
+					data
+				};
+			}
+    }) : compose;
+
+const store = createStore( persistedReducer, composeEnhancers(
 	applyMiddleware( routerMiddleware( history ), thunk )
 ) );
 
-let persistor = persistStore( store );
+const persistor = persistStore( store );
 
 class App extends React.Component{
 	constructor(props) {


### PR DESCRIPTION
Firefox was showing the "Sorry :(" error page and refusing to load; was throwing a Redux error but the code in question seemed fine. Figured out it must relate to the Redux DevTools extension which I had installed - it was using a deprecated approach for initialisation.

This PR updates it and adds an optimisation to improve performance (was previously loading entire text of translations from state).

The original error is no longer occurring in Firefox... though not an issue likely to affect many users admittedly!